### PR TITLE
fix(chore): get explorer api link from hyperchain config file

### DIFF
--- a/packages/app/src/components/TheFooter.vue
+++ b/packages/app/src/components/TheFooter.vue
@@ -25,12 +25,14 @@
 import { computed, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 
+import config from "@/configs/hyperchain.config.json";
+
 const { t } = useI18n();
 
 const navigation = reactive([
   {
     label: computed(() => t("footer.nav.docs")),
-    url: `https://block-explorer-api.testnet.sophon.xyz/docs`,
+    url: `${config.networks[0].apiUrl}/docs`,
   },
   {
     label: computed(() => t("footer.nav.terms")),

--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -119,6 +119,8 @@ import TwitterIcon from "@/components/icons/TwitterIcon.vue";
 
 import useContext from "@/composables/useContext";
 
+import config from "@/configs/hyperchain.config.json";
+
 const { t } = useI18n({ useScope: "global" });
 const { currentNetwork } = useContext();
 
@@ -128,7 +130,7 @@ const logoImage =
 const navigation = reactive([
   {
     label: computed(() => t("header.nav.documentation")),
-    url: `https://block-explorer-api.testnet.sophon.xyz/docs`,
+    url: `${config.networks[0].apiUrl}/docs`,
   },
 ]);
 
@@ -154,7 +156,7 @@ const blockExplorerLinks = reactive([
 const links = [
   {
     label: computed(() => t("header.nav.apiDocs")),
-    url: computed(() => "https://block-explorer-api.testnet.sophon.xyz/docs"),
+    url: computed(() => `${config.networks[0].apiUrl}/docs`),
   },
   {
     label: computed(() => t("header.nav.contractVerification")),


### PR DESCRIPTION
## Changes
- Replaced https://block-explorer-api.testnet.sophon.xyz/ hardcoded url to use config file instead