### PR TITLE
feat: adds excluded tokens list per network

### DIFF
--- a/packages/app/src/composables/useContext.ts
+++ b/packages/app/src/composables/useContext.ts
@@ -30,9 +30,21 @@ export default (): Context => {
       ? environmentConfig.networks.value
       : [DEFAULT_NETWORK];
   });
+
+  const getDefaultNetworkByHost = (hostname: string) => {
+    if (hostname.includes("explorer.testnet") || hostname.includes("localhost")) {
+      // safe check in case we only have one network
+      if (!networks.value[1]) return networks.value[0];
+      return networks.value[1];
+    }
+    return networks.value[0];
+  };
+
   const currentNetwork = computed(() => {
     return (
-      networks.value.find((networkEntry) => networkEntry.name === network.value) ?? networks.value[0] ?? DEFAULT_NETWORK
+      networks.value.find((networkEntry) => networkEntry.name === network.value) ??
+      getDefaultNetworkByHost(window.location.hostname) ??
+      DEFAULT_NETWORK
     );
   });
 

--- a/packages/app/src/composables/useTokenLibrary.ts
+++ b/packages/app/src/composables/useTokenLibrary.ts
@@ -46,7 +46,11 @@ const retrieveTokens = useMemoize(
       }
     }
 
-    return tokens;
+    const filteredTokens = tokens.filter(
+      (token) => !context.currentNetwork.value.excludeTokenAddresses?.includes(token.l2Address)
+    );
+
+    return filteredTokens;
   },
   {
     getKey(context: Context) {

--- a/packages/app/src/configs/hyperchain.config.json
+++ b/packages/app/src/configs/hyperchain.config.json
@@ -1,20 +1,6 @@
 {
   "networks": [
     {
-      "apiUrl": "https://block-explorer-api.testnet.sophon.xyz",
-      "verificationApiUrl": "https://api-explorer-verify.testnet.sophon.xyz",
-      "bridgeUrl": "https://portal.testnet.sophon.xyz/bridge",
-      "hostnames": ["https://explorer.testnet.sophon.xyz"],
-      "icon": "/images/icons/sophon.svg",
-      "l2ChainId": 531050104,
-      "l2NetworkName": "Sophon Testnet",
-      "maintenance": false,
-      "name": "Sepolia",
-      "l1ExplorerUrl": "https://sepolia.etherscan.io",
-      "published": true,
-      "rpcUrl": "https://rpc.testnet.sophon.xyz"
-    },
-    {
       "apiUrl": "https://api-explorer.sophon.xyz",
       "verificationApiUrl": "https://verification-explorer.sophon.xyz",
       "bridgeUrl": "https://portal.sophon.xyz/bridge",
@@ -26,7 +12,23 @@
       "name": "Ethereum",
       "l1ExplorerUrl": "https://etherscan.io",
       "published": true,
-      "rpcUrl": "https://rpc.sophon.xyz"
+      "rpcUrl": "https://rpc.sophon.xyz",
+      "excludeTokenAddresses": []
+    },
+    {
+      "apiUrl": "https://block-explorer-api.testnet.sophon.xyz",
+      "verificationApiUrl": "https://api-explorer-verify.testnet.sophon.xyz",
+      "bridgeUrl": "https://portal.testnet.sophon.xyz/bridge",
+      "hostnames": ["https://explorer.testnet.sophon.xyz"],
+      "icon": "/images/icons/sophon.svg",
+      "l2ChainId": 531050104,
+      "l2NetworkName": "Sophon Testnet",
+      "maintenance": false,
+      "name": "Sepolia",
+      "l1ExplorerUrl": "https://sepolia.etherscan.io",
+      "published": true,
+      "rpcUrl": "https://rpc.testnet.sophon.xyz",
+      "excludeTokenAddresses": []
     }
   ]
 }

--- a/packages/app/src/configs/index.ts
+++ b/packages/app/src/configs/index.ts
@@ -13,6 +13,7 @@ export type NetworkConfig = {
   hostnames: string[];
   tokensMinLiquidity?: number;
   zkTokenAddress?: string;
+  excludeTokenAddresses?: string[];
 };
 
 export type EnvironmentConfig = {

--- a/packages/app/tests/components/NetworkSwitch.spec.ts
+++ b/packages/app/tests/components/NetworkSwitch.spec.ts
@@ -35,7 +35,7 @@ describe("NetworkSwitch:", () => {
 
   it("renders listbox button with selected option", async () => {
     const { container } = render(NetworkSwitch);
-    expect(container.querySelector(".network-item-label")?.textContent).toBe("Testnet");
+    expect(container.querySelector(".network-item-label")?.textContent).toBe("Testnet Beta");
   });
 
   it("renders list of networks when button is clicked", async () => {
@@ -47,11 +47,11 @@ describe("NetworkSwitch:", () => {
     const options = container.querySelectorAll(".network-list-item-container > *");
     expect(options[0].getAttribute("href")).toBe("?network=testnet");
     expect(options[0].textContent).toBe("Testnet");
-    expect(options[0].tagName).toBe("LABEL");
+    expect(options[0].tagName).toBe("A");
     expect(options[0].querySelector("img")?.getAttribute("alt")).toBe("Testnet logo");
     expect(options[1].getAttribute("href")).toBe("https://testnet-beta.staging-scan-v2.zksync.dev/");
     expect(options[1].textContent).toBe("Testnet Beta");
-    expect(options[1].tagName).toBe("A");
+    expect(options[1].tagName).toBe("LABEL");
     expect(options[1].querySelector("img")?.getAttribute("alt")).toBe("Testnet Beta logo");
   });
 
@@ -66,10 +66,10 @@ describe("NetworkSwitch:", () => {
     const options = container.querySelectorAll(".network-list-item-container > *");
     expect(options[0].getAttribute("href")).toBe("?network=testnet");
     expect(options[0].textContent).toBe("Testnet");
-    expect(options[0].tagName).toBe("LABEL");
+    expect(options[0].tagName).toBe("A");
     expect(options[1].getAttribute("href")).toBe("?network=testnet-beta");
     expect(options[1].textContent).toBe("Testnet Beta");
-    expect(options[1].tagName).toBe("A");
+    expect(options[1].tagName).toBe("LABEL");
   });
 
   it("uses relative url schema for networks when on preview deployment (.web.app)", async () => {
@@ -82,9 +82,9 @@ describe("NetworkSwitch:", () => {
     const options = container.querySelectorAll(".network-list-item-container > *");
     expect(options[0].getAttribute("href")).toBe("?network=testnet");
     expect(options[0].textContent).toBe("Testnet");
-    expect(options[0].tagName).toBe("LABEL");
+    expect(options[0].tagName).toBe("A");
     expect(options[1].getAttribute("href")).toBe("?network=testnet-beta");
     expect(options[1].textContent).toBe("Testnet Beta");
-    expect(options[1].tagName).toBe("A");
+    expect(options[1].tagName).toBe("LABEL");
   });
 });


### PR DESCRIPTION
# What ❔
- A list of tokens to be excluded, per network;
- a `getDefaultNetworkByHost` method to detects if the hostname is explorer.testnet.sophon.xyz so it defaults to `testnet` as the first chain, else it uses the standard config file order;
- Changes the config file network order. 

## Why ❔
- Excluded tokens: This could allow us to hide tokens from tokens list if there's ever a need.
- Network order: so we can keep the config the same across environments, using `getDefaultNetworkByHost` to define the network for each case
