### PR TITLE
fix: remove api documentation link

### DIFF
--- a/packages/app/src/components/header/TheHeader.vue
+++ b/packages/app/src/components/header/TheHeader.vue
@@ -121,6 +121,8 @@ import useContext from "@/composables/useContext";
 
 import config from "@/configs/hyperchain.config.json";
 
+import type { NavLink } from "@/types";
+
 const { t } = useI18n({ useScope: "global" });
 const { currentNetwork } = useContext();
 
@@ -153,11 +155,7 @@ const blockExplorerLinks = reactive([
   },
 ]);
 
-const links = [
-  {
-    label: computed(() => t("header.nav.apiDocs")),
-    url: computed(() => `${config.networks[0].apiUrl}/docs`),
-  },
+const links: NavLink[] = [
   {
     label: computed(() => t("header.nav.contractVerification")),
     to: { name: "contract-verification" },

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -1,3 +1,5 @@
+import type { ComputedRef } from "vue";
+
 export type Hash = `0x${string}` | string;
 
 export type Address = Hash;
@@ -59,3 +61,9 @@ export type ContractVerificationData = {
 };
 
 export type ContractVerificationStatus = "successful" | "failed" | "in_progress" | "queued";
+
+export type NavLink = {
+  label: ComputedRef<string>;
+  to?: { name: string };
+  url?: ComputedRef<string>;
+};

--- a/packages/app/tests/components/TheHeader.spec.ts
+++ b/packages/app/tests/components/TheHeader.spec.ts
@@ -58,9 +58,8 @@ describe("TheHeader:", () => {
     await fireEvent.click(dropdown[1].find("button")!.element);
     const toolsLinksRouter = dropdown[1].findAllComponents(RouterLinkStub);
     const toolsLinks = dropdown[1].findAll("a");
-    expect(toolsLinks[0].attributes("href")).toBe(`${config.networks[0].apiUrl}/docs`);
     expect(toolsLinksRouter[0].props().to.name).toBe("contract-verification");
-    expect(toolsLinks[2].attributes("href")).toBe("https://bridge.zksync.io/");
+    expect(toolsLinks[1].attributes("href")).toBe("https://bridge.zksync.io/");
 
     expect(wrapper.findAll(".navigation-container > .navigation-link")[0].attributes("href")).toBe(
       `${config.networks[0].apiUrl}/docs`


### PR DESCRIPTION
# What ❔
Removes `API Documentation` link

## Why ❔
Documentation and API Documentation points to the same page

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
