### PR TITLE
fix: show SOPH instead of ETH

### DIFF
--- a/packages/app/src/composables/useToken.ts
+++ b/packages/app/src/composables/useToken.ts
@@ -11,8 +11,20 @@ import type { Hash } from "@/types";
 export type Token = Api.Response.Token;
 
 export const retrieveToken = useMemoize(
-  (tokenAddress: Hash, context: Context = useContext()): Promise<Api.Response.Token> => {
-    return $fetch(`${context.currentNetwork.value.apiUrl}/tokens/${tokenAddress}`);
+  async (tokenAddress: Hash, context: Context = useContext()): Promise<Api.Response.Token> => {
+    const token = await $fetch(`${context.currentNetwork.value.apiUrl}/tokens/${tokenAddress}`);
+
+    // Force name for specific token address
+    // TODO: Remove this once ML fixes the token info
+    if (tokenAddress.toLowerCase() === "0x000000000000000000000000000000000000800A".toLowerCase()) {
+      return {
+        ...token,
+        name: "SOPH",
+        symbol: "SOPH",
+      };
+    }
+
+    return token;
   },
   {
     getKey(tokenAddress: Hash, context: Context = useContext()) {

--- a/packages/app/src/composables/useTokenLibrary.ts
+++ b/packages/app/src/composables/useTokenLibrary.ts
@@ -50,6 +50,19 @@ const retrieveTokens = useMemoize(
       (token) => !context.currentNetwork.value.excludeTokenAddresses?.includes(token.l2Address)
     );
 
+    // Force name for specific token address
+    // TODO: Remove this once ML fixes the token info
+    const sophonTokenIndex = filteredTokens.findIndex(
+      (token) => token.l2Address.toLowerCase() === "0x000000000000000000000000000000000000800A".toLowerCase()
+    );
+    if (sophonTokenIndex !== -1) {
+      filteredTokens[sophonTokenIndex] = {
+        ...filteredTokens[sophonTokenIndex],
+        name: "SOPH",
+        symbol: "SOPH",
+      };
+    }
+
     return filteredTokens;
   },
   {


### PR DESCRIPTION
# What ❔
Force name and symbol for specific token address

## Why ❔

Matter Labs pushed a change that changed our explorer to show SOPH as ETH. They are working on a quick fix ASAP but we should have a hot fix prepared in case it takes longer.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
