### PR TITLE
[SOP-705] fix: handling of zero values in hexadecimal formatting

### DIFF
--- a/packages/app/src/utils/formatters.ts
+++ b/packages/app/src/utils/formatters.ts
@@ -62,11 +62,20 @@ export function convert(value: BigNumberish | null, token: Token | null, tokenPr
 export function formatHexDecimals(value: string, showValueAs: HexDecimals) {
   const validValue = value === "0x" ? "0" : value;
   const prefix = isHexString(validValue) ? "" : "0x";
+
   if (showValueAs === "Dec") {
     return BigInt(prefix + validValue).toString();
   }
+
+  if (showValueAs === "Hex" && value.length >= 42) {
+    const hexValue = validValue.replace(/^0x/, "");
+    const addressHex = hexValue.slice(-40);
+    return `0x${addressHex}`;
+  }
+
   return `0x${BigInt(prefix + validValue).toString(16)}`;
 }
+
 export const numberToHexString = (num: number | bigint) => `0x${num.toString(16)}`;
 
 export function formatPricePretty(amount: BigNumberish, decimals: number, usdPrice: string) {


### PR DESCRIPTION
# What ❔

- Added logic to format hexadecimal values as Ethereum addresses when the input length is 42 characters or more.
- Improved handling of zero values in hexadecimal formatting.

## Why ❔

Event address is not clickable as it cuts a 0 at the beginning

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
