### PR TITLE
fix: return blacklisted address to not use paymaster

### DIFF
--- a/packages/app/src/composables/useContractInteraction.ts
+++ b/packages/app/src/composables/useContractInteraction.ts
@@ -10,6 +10,7 @@ import type { AbiFragment } from "./useAddress";
 import type { Signer } from "zksync-ethers";
 
 import { checkIsPaymasterWhitelisted, PAYMASTER_ADDRESS } from "@/utils/checkIsPaymasterWhitelisted";
+import { BLACKLISTED_ACCOUNT_ADDRESSES } from "@/utils/constants";
 
 export const PAYABLE_AMOUNT_PARAM_NAME = "payable_function_payable_amount";
 
@@ -74,6 +75,10 @@ export default (context = useContext()) => {
 
       let res;
       const signerAddress = await signer.getAddress();
+
+      if (BLACKLISTED_ACCOUNT_ADDRESSES.includes(signerAddress)) {
+        usePaymaster = false;
+      }
 
       // Check if the contract is whitelisted for paymaster sponsorship
       if (usePaymaster) {

--- a/packages/app/src/utils/checkIsPaymasterWhitelisted.ts
+++ b/packages/app/src/utils/checkIsPaymasterWhitelisted.ts
@@ -1,23 +1,23 @@
 /**
  * Paymaster address on Sophon network
  */
-export const PAYMASTER_ADDRESS = '0x98546B226dbbA8230cf620635a1e4ab01F6A99B2'
+export const PAYMASTER_ADDRESS = "0x98546B226dbbA8230cf620635a1e4ab01F6A99B2";
 
 /**
  * Paymaster whitelist contract address on Sophon network
  * This contract maintains a list of contracts that are approved for gas sponsorship
  */
-export const PAYMASTER_WHITELIST_ADDRESS = '0x786c188eb7021578D8db247B66f5E356faAb2a88'
+export const PAYMASTER_WHITELIST_ADDRESS = "0x786c188eb7021578D8db247B66f5E356faAb2a88";
 
 export const PAYMASTER_WHITELIST_ABI = [
-    {
-        inputs: [{ name: '', type: 'address', internalType: 'address' }],
-        name: 'contractWhitelist',
-        outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
-        stateMutability: 'view',
-        type: 'function',
-    },
-] as const
+  {
+    inputs: [{ name: "", type: "address", internalType: "address" }],
+    name: "contractWhitelist",
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
 
 /**
  * Checks if a contract is whitelisted by the paymaster
@@ -29,27 +29,20 @@ export const PAYMASTER_WHITELIST_ABI = [
  * @param provider - The provider to make the contract call
  * @returns Promise<boolean> - true if the contract is whitelisted, false otherwise
  */
-export const checkIsPaymasterWhitelisted = async (
-    contractAddress: string,
-    provider: any
-): Promise<boolean> => {
-    try {
-        if (!provider) {
-            return false
-        }
-
-        // Using ethers.js Contract for compatibility with block-explorer
-        const { Contract } = await import('ethers')
-        const whitelistContract = new Contract(
-            PAYMASTER_WHITELIST_ADDRESS,
-            PAYMASTER_WHITELIST_ABI,
-            provider
-        )
-        
-        const result = await whitelistContract.contractWhitelist(contractAddress)
-        
-        return result
-    } catch (err: unknown) {
-        return false
+export const checkIsPaymasterWhitelisted = async (contractAddress: string, provider: any): Promise<boolean> => {
+  try {
+    if (!provider) {
+      return false;
     }
-}
+
+    // Using ethers.js Contract for compatibility with block-explorer
+    const { Contract } = await import("ethers");
+    const whitelistContract = new Contract(PAYMASTER_WHITELIST_ADDRESS, PAYMASTER_WHITELIST_ABI, provider);
+
+    const result = await whitelistContract.contractWhitelist(contractAddress);
+
+    return result;
+  } catch (err: unknown) {
+    return false;
+  }
+};

--- a/packages/app/src/utils/constants.ts
+++ b/packages/app/src/utils/constants.ts
@@ -47,3 +47,5 @@ export const EVM_VERSION_TO_TARGET = [
   "shanghai",
   "cancun",
 ];
+
+export const BLACKLISTED_ACCOUNT_ADDRESSES = ["0xAb8F5806b9e13F06e824C4a41B0Ef5156EcDEE1b"];


### PR DESCRIPTION
## Changes
- Reverted some changes from https://github.com/sophon-org/block-explorer/pull/63 add back blacklisted address that isn't supposed to use the paymaster. Original change was https://github.com/sophon-org/block-explorer/pull/62


